### PR TITLE
Fix npm tests and add FastAPI test

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "deploy:test": "shopify theme push --path=theme --env=test",
     "deploy:prod": "shopify theme push --path=theme --env=prod",
     "lighthouse": "npx @lhci/cli@0.16.x autorun --collect.url=https://${SHOP_URL}",
-    "test": "jest",
+    "test": "node --test",
     "test:e2e": "playwright test"
   },
   "dependencies": {

--- a/tests/package.test.js
+++ b/tests/package.test.js
@@ -1,0 +1,9 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { readFileSync } = require('node:fs');
+
+const pkg = JSON.parse(readFileSync('./package.json', 'utf8'));
+
+test('package name', () => {
+  assert.strictEqual(pkg.name, 'shopify-ec-manager');
+});

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,7 @@
+import asyncio
+from backend.app.main import root
+
+
+def test_root_direct():
+    result = asyncio.run(root())
+    assert result['status'] == 'operational'


### PR DESCRIPTION
## Summary
- switch `npm test` to use the Node test runner
- add a basic package.json test
- add a FastAPI root test that doesn't need httpx

## Testing
- `npm test`
- `pytest -q`
